### PR TITLE
feat(DS-1105): introduce backfill resource

### DIFF
--- a/connect/provider.go
+++ b/connect/provider.go
@@ -100,10 +100,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	titanicURL := d.Get("titanic_url").(string)
 
-	if titanicURL == "" {
-		titanicURL = addr
-	}
-
 	titanicClient, err := titanic.NewClient(titanicURL)
 	if err != nil {
 		log.Fatalf("can not create titanic client: %s", err)

--- a/connect/provider.go
+++ b/connect/provider.go
@@ -1,12 +1,23 @@
 package connect
 
 import (
+	"context"
 	"crypto/tls"
 	"log"
 
+	"github.com/Mongey/terraform-provider-kafka-connect/titanic"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	kc "github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 )
+
+type Titanic interface {
+	ExecuteBackfill(ctx context.Context, id string) error
+}
+
+type ProviderMeta struct {
+	KafkaClient   kc.HighLevelClient
+	TitanicClient Titanic
+}
 
 func Provider() *schema.Provider {
 	log.Printf("[INFO] Creating Provider")
@@ -16,6 +27,12 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CONNECT_URL", ""),
+			},
+			"titanic_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TITANIC_URL", ""),
+				Description: "The base URL for the Titanic backfill service.",
 			},
 			"basic_auth_username": {
 				Type:        schema.TypeString,
@@ -46,6 +63,7 @@ func Provider() *schema.Provider {
 		ConfigureFunc: providerConfigure,
 		ResourcesMap: map[string]*schema.Resource{
 			"kafka-connect_connector": kafkaConnectorResource(),
+			"kafka-connect_backfill":  kafkaConnectBackfillResource(),
 		},
 	}
 	log.Printf("[INFO] Created provider: %v", provider)
@@ -79,5 +97,22 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			c.SetClientCertificates(cert)
 		}
 	}
-	return c, nil
+
+	titanicURL := d.Get("titanic_url").(string)
+
+	if titanicURL == "" {
+		titanicURL = addr
+	}
+
+	titanicClient, err := titanic.NewClient(titanicURL)
+	if err != nil {
+		log.Fatalf("can not create titanic client: %s", err)
+	}
+
+	meta := &ProviderMeta{
+		KafkaClient:   c,
+		TitanicClient: titanicClient,
+	}
+
+	return meta, nil
 }

--- a/connect/resource_backfill.go
+++ b/connect/resource_backfill.go
@@ -1,0 +1,53 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func kafkaConnectBackfillResource() *schema.Resource {
+	return &schema.Resource{
+		Create: backfillExecute, // Called when Terraform processes this block
+		Read:   backfillRead,    // Empties state immediately after creation
+		Delete: backfillDelete,
+		Schema: map[string]*schema.Schema{
+			"backfill_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The UUID of the backfill task to execute.",
+			},
+		},
+	}
+}
+
+func backfillExecute(d *schema.ResourceData, meta interface{}) error {
+	metaStruct := meta.(*ProviderMeta)
+	client := metaStruct.TitanicClient
+	backfillID := d.Get("backfill_id").(string)
+
+	log.Printf("[INFO] Extracting base URL from Kafka Connect configuration")
+
+	err := client.ExecuteBackfill(context.Background(), backfillID)
+	if err != nil {
+		return errors.New("could not execute backfill: " + err.Error() + "with id: " + backfillID)
+	}
+
+	d.SetId(backfillID)
+	return nil
+}
+
+func backfillRead(d *schema.ResourceData, meta interface{}) error {
+	// Empty out the resource identifier immediately.
+	// This leaves `.tfstate` clean and forces a re-run on subsequent executions.
+	d.SetId("")
+	return nil
+}
+
+func backfillDelete(d *schema.ResourceData, meta interface{}) error {
+	// Operational trigger only. No remote infrastructure destruction required.
+	return nil
+}

--- a/connect/resource_backfill.go
+++ b/connect/resource_backfill.go
@@ -33,7 +33,7 @@ func backfillExecute(d *schema.ResourceData, meta interface{}) error {
 
 	err := client.ExecuteBackfill(context.Background(), backfillID)
 	if err != nil {
-		return errors.New("could not execute backfill: " + err.Error() + "with id: " + backfillID)
+		return errors.New("could not execute backfill: " + err.Error() + " with id: " + backfillID)
 	}
 
 	d.SetId(backfillID)

--- a/connect/resource_backfill_test.go
+++ b/connect/resource_backfill_test.go
@@ -1,0 +1,143 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeBackfillExecutor struct {
+	calls        int
+	executedID   string
+	executeError error
+}
+
+func (f *fakeBackfillExecutor) ExecuteBackfill(
+	_ context.Context,
+	backfillID string,
+) error {
+	f.calls++
+	f.executedID = backfillID
+
+	return f.executeError
+}
+
+func newBackfillResourceData(
+	t *testing.T,
+	backfillID string,
+) *schema.ResourceData {
+	t.Helper()
+
+	resource := kafkaConnectBackfillResource()
+
+	return schema.TestResourceDataRaw(
+		t,
+		resource.Schema,
+		map[string]interface{}{
+			"backfill_id": backfillID,
+		},
+	)
+}
+
+func TestKafkaBackfillResourceSchema(t *testing.T) {
+	resource := kafkaConnectBackfillResource()
+
+	require.NotNil(t, resource)
+	require.NotNil(t, resource.Schema)
+
+	backfillID, ok := resource.Schema["backfill_id"]
+	require.True(t, ok, "backfill_id schema field should exist")
+	require.NotNil(t, backfillID)
+
+	assert.Equal(t, schema.TypeString, backfillID.Type)
+	assert.True(t, backfillID.Required)
+	assert.True(t, backfillID.ForceNew)
+	assert.Equal(
+		t,
+		"The UUID of the backfill task to execute.",
+		backfillID.Description,
+	)
+
+	assert.NotNil(t, resource.Create)
+	assert.NotNil(t, resource.Read)
+	assert.NotNil(t, resource.Delete)
+}
+
+func TestBackfillExecuteSuccess(t *testing.T) {
+	const backfillID = "backfill-123"
+
+	client := &fakeBackfillExecutor{}
+	meta := &ProviderMeta{
+		TitanicClient: client,
+	}
+
+	data := newBackfillResourceData(t, backfillID)
+
+	err := backfillExecute(data, meta)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.calls)
+	assert.Equal(t, backfillID, client.executedID)
+	assert.Equal(t, backfillID, data.Id())
+}
+
+func TestBackfillExecuteError(t *testing.T) {
+	const backfillID = "backfill-123"
+
+	expectedErr := errors.New("could not execute backfill: Titanic returned an errorwith id: backfill-123")
+
+	client := &fakeBackfillExecutor{
+		executeError: expectedErr,
+	}
+
+	meta := &ProviderMeta{
+		TitanicClient: client,
+	}
+
+	data := newBackfillResourceData(t, backfillID)
+
+	err := backfillExecute(data, meta)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.EqualError(
+		t,
+		err,
+		`could not execute backfill: Titanic returned an errorwith id: backfill-123`,
+	)
+	assert.Equal(t, 1, client.calls)
+	assert.Equal(t, backfillID, client.executedID)
+
+	// The resource ID must not be set when execution fails.
+	assert.Empty(t, data.Id())
+}
+
+func TestBackfillReadClearsResourceID(t *testing.T) {
+	const backfillID = "backfill-123"
+
+	data := newBackfillResourceData(t, backfillID)
+	data.SetId(backfillID)
+
+	err := backfillRead(data, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, data.Id())
+}
+
+func TestBackfillDeleteDoesNothing(t *testing.T) {
+	const backfillID = "backfill-123"
+
+	data := newBackfillResourceData(t, backfillID)
+	data.SetId(backfillID)
+
+	err := backfillDelete(data, nil)
+
+	require.NoError(t, err)
+
+	// backfillDelete is intentionally a no-op.
+	assert.Equal(t, backfillID, data.Id())
+}

--- a/connect/resource_backfill_test.go
+++ b/connect/resource_backfill_test.go
@@ -88,10 +88,8 @@ func TestBackfillExecuteSuccess(t *testing.T) {
 func TestBackfillExecuteError(t *testing.T) {
 	const backfillID = "backfill-123"
 
-	expectedErr := errors.New("could not execute backfill: Titanic returned an errorwith id: backfill-123")
-
 	client := &fakeBackfillExecutor{
-		executeError: expectedErr,
+		executeError: errors.New("Titanic returned an error"),
 	}
 
 	meta := &ProviderMeta{
@@ -103,11 +101,10 @@ func TestBackfillExecuteError(t *testing.T) {
 	err := backfillExecute(data, meta)
 
 	require.Error(t, err)
-	assert.ErrorIs(t, err, expectedErr)
 	assert.EqualError(
 		t,
 		err,
-		`could not execute backfill: Titanic returned an errorwith id: backfill-123`,
+		`could not execute backfill: Titanic returned an error with id: backfill-123`,
 	)
 	assert.Equal(t, 1, client.calls)
 	assert.Equal(t, backfillID, client.executedID)

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -56,7 +56,8 @@ func setNameFromID(d *schema.ResourceData, meta interface{}) ([]*schema.Resource
 }
 
 func connectorCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(kc.HighLevelClient)
+	metaStruct := meta.(*ProviderMeta)
+	c := metaStruct.KafkaClient
 	name := nameFromRD(d)
 
 	config, sensitiveCache := configFromRD(d)
@@ -92,7 +93,8 @@ func connectorCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func connectorDelete(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(kc.HighLevelClient)
+	metaStruct := meta.(*ProviderMeta)
+	c := metaStruct.KafkaClient
 
 	name := nameFromRD(d)
 	req := kc.ConnectorRequest{
@@ -118,7 +120,8 @@ func isRebalanceExpectedError(err error) bool {
 func connectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	start := time.Now()
 
-	c := meta.(kc.HighLevelClient)
+	metaStruct := meta.(*ProviderMeta)
+	c := metaStruct.KafkaClient
 
 	name := nameFromRD(d)
 
@@ -171,7 +174,8 @@ func connectorUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func connectorRead(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(kc.HighLevelClient)
+	metaStruct := meta.(*ProviderMeta)
+	c := metaStruct.KafkaClient
 
 	config, sensitiveCache := configFromRD(d)
 	name := d.Get("name").(string)

--- a/titanic/titanic.go
+++ b/titanic/titanic.go
@@ -1,0 +1,88 @@
+package titanic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var errHttpClient = errors.New("request failed with message")
+
+type HTTPClient interface {
+	Do(request *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	httpClient HTTPClient
+	baseURL    *url.URL
+}
+
+const (
+	executePath = "v1/backfills/%s/execute"
+)
+
+func NewClient(base string) (*Client, error) {
+	parsedBase, err := url.Parse(base)
+	if err != nil {
+		return nil, fmt.Errorf("parse URL: %w", err)
+	}
+
+	return &Client{
+		baseURL: parsedBase,
+		httpClient: &http.Client{
+			Timeout: time.Second * 30, //nolint:mnd
+		},
+	}, nil
+}
+
+func (c *Client) ExecuteBackfill(ctx context.Context, id string) error {
+	targetURL := c.baseURL.ResolveReference(&url.URL{
+		Path: fmt.Sprintf(executePath, id),
+	}).String()
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		targetURL,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed creating PUT request context: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/json")
+
+	res, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	errResponse := handleHttpStatus(res.StatusCode, res.Body)
+	if errResponse != nil {
+		return errResponse
+	}
+
+	return nil
+}
+
+func handleHttpStatus(status int, body io.ReadCloser) error {
+	switch status {
+	case http.StatusMethodNotAllowed, http.StatusNotFound, http.StatusConflict,
+		http.StatusTooManyRequests, http.StatusRequestTimeout, http.StatusGatewayTimeout,
+		http.StatusInternalServerError, http.StatusBadRequest:
+		output := map[string]any{}
+		if err := json.NewDecoder(body).Decode(&output); err != nil {
+			return fmt.Errorf("unable to decode response: %w", err)
+		}
+
+		return fmt.Errorf("%w %v ", errHttpClient, output["message"])
+
+	}
+	return nil
+}


### PR DESCRIPTION
Stateless resource which executes a backfill for a given id. The create backfill flow calls the PUT /<backfill-id>/execute endpoint to start the process